### PR TITLE
move VeDist and Voter addresses to Controller, make them changeable

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.13;
+
+import "./interface/IController.sol";
+
+contract Controller is IController {
+
+  address public governance;
+  address public pendingGovernance;
+
+  address public veDist;
+  address public voter;
+
+  event SetGovernance(address value);
+  event SetVeDist(address value);
+  event SetVoter(address value);
+
+  constructor() {
+    governance = msg.sender;
+  }
+
+  modifier onlyGov() {
+    require(msg.sender == governance, "Not gov");
+    _;
+  }
+
+  function setGovernance(address _value) external onlyGov {
+    pendingGovernance = _value;
+    emit SetGovernance(_value);
+  }
+
+  function acceptGovernance() external {
+    require(msg.sender == pendingGovernance, "Not pending gov");
+    governance = pendingGovernance;
+  }
+
+  function setVeDist(address _value) external onlyGov {
+    veDist = _value;
+    emit SetVeDist(_value);
+  }
+
+  function setVoter(address _value) external onlyGov {
+    voter = _value;
+    emit SetVoter(_value);
+  }
+
+}

--- a/contracts/base/reward/BribeFactory.sol
+++ b/contracts/base/reward/BribeFactory.sol
@@ -8,12 +8,15 @@ import "../../interface/IBribeFactory.sol";
 contract BribeFactory is IBribeFactory {
   address public lastGauge;
 
+  event BribeCreated(address value);
+
   function createBribe(address[] memory _allowedRewardTokens) external override returns (address) {
     address _lastGauge = address(new Bribe(
         msg.sender,
         _allowedRewardTokens
       ));
     lastGauge = _lastGauge;
+    emit BribeCreated(_lastGauge);
     return _lastGauge;
   }
 }

--- a/contracts/base/reward/GaugeFactory.sol
+++ b/contracts/base/reward/GaugeFactory.sol
@@ -8,6 +8,8 @@ import "./Gauge.sol";
 contract GaugeFactory is IGaugeFactory {
   address public lastGauge;
 
+  event GaugeCreated(address value);
+
   function createGauge(
     address _pool,
     address _bribe,
@@ -16,6 +18,7 @@ contract GaugeFactory is IGaugeFactory {
   ) external override returns (address) {
     address _lastGauge = address(new Gauge(_pool, _bribe, _ve, msg.sender, _allowedRewardTokens));
     lastGauge = _lastGauge;
+    emit GaugeCreated(_lastGauge);
     return _lastGauge;
   }
 
@@ -28,6 +31,7 @@ contract GaugeFactory is IGaugeFactory {
   ) external override returns (address) {
     address _lastGauge = address(new Gauge(_pool, _bribe, _ve, _voter, _allowedRewardTokens));
     lastGauge = _lastGauge;
+    emit GaugeCreated(_lastGauge);
     return _lastGauge;
   }
 }

--- a/contracts/interface/IController.sol
+++ b/contracts/interface/IController.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.13;
+
+interface IController {
+
+  function veDist() external view returns (address);
+
+  function voter() external view returns (address);
+
+}

--- a/scripts/deploy/Deploy.ts
+++ b/scripts/deploy/Deploy.ts
@@ -6,6 +6,7 @@ import {BigNumber, ContractFactory, utils} from "ethers";
 import {Libraries} from "hardhat-deploy/dist/types";
 import {
   BribeFactory,
+  Controller,
   Dyst,
   DystFactory,
   DystMinter,
@@ -102,8 +103,8 @@ export class Deploy {
     return (await Deploy.deployContract(signer, 'DystRouter01', factory, networkToken)) as DystRouter01;
   }
 
-  public static async deployVe(signer: SignerWithAddress, token: string) {
-    return (await Deploy.deployContract(signer, 'Ve', token)) as Ve;
+  public static async deployVe(signer: SignerWithAddress, token: string, controller: string) {
+    return (await Deploy.deployContract(signer, 'Ve', token, controller)) as Ve;
   }
 
   public static async deployVeDist(signer: SignerWithAddress, ve: string) {
@@ -129,17 +130,15 @@ export class Deploy {
 
   public static async deployDystMinter(
     signer: SignerWithAddress,
-    voter: string,
     ve: string,
-    veDist: string,
+    controller: string,
     warmingUpPeriod: number
   ) {
     return (await Deploy.deployContract(
       signer,
       'DystMinter',
-      voter,
       ve,
-      veDist,
+      controller,
       warmingUpPeriod,
     )) as DystMinter;
   }
@@ -153,40 +152,38 @@ export class Deploy {
     minterSum: BigNumber,
     warmingUpPeriod = 2
   ) {
-    const treasury = await Deploy.deployGovernanceTreasury(signer);
-    const token = await Deploy.deployDyst(signer);
-    const gaugesFactory = await Deploy.deployGaugeFactory(signer);
-    const bribesFactory = await Deploy.deployBribeFactory(signer);
-    const baseFactory = await Deploy.deployDystFactory(signer, treasury.address);
+    const [baseFactory, router, treasury] = await Deploy.deployDex(signer, networkToken);
 
-    const router = await Deploy.deployDystRouter01(signer, baseFactory.address, networkToken);
-    const ve = await Deploy.deployVe(signer, token.address);
-    const veDist = await Deploy.deployVeDist(signer, ve.address);
-    const voter = await Deploy.deployDystVoter(signer, ve.address, baseFactory.address, gaugesFactory.address, bribesFactory.address);
-    const minter = await Deploy.deployDystMinter(signer, voter.address, ve.address, veDist.address, warmingUpPeriod);
-
-    await Misc.runAndWait(() => token.setMinter(minter.address));
-    await Misc.runAndWait(() => ve.setVoter(voter.address));
-    await Misc.runAndWait(() => veDist.setDepositor(minter.address));
-
-    await Misc.runAndWait(() => voter.initialize(voterTokens, minter.address));
-    await Misc.runAndWait(() => minter.initialize(
-      minterClaimants,
-      minterClaimantsAmounts,
-      minterSum
-    ));
-
-    return new CoreAddresses(
+    const [
       token,
       gaugesFactory,
       bribesFactory,
-      baseFactory,
-      router,
       ve,
       veDist,
       voter,
       minter,
-      treasury
+    ] = await Deploy.deployDystSystem(
+      signer,
+      networkToken,
+      voterTokens,
+      minterClaimants,
+      minterClaimantsAmounts,
+      minterSum,
+      baseFactory.address,
+      warmingUpPeriod,
+    );
+
+    return new CoreAddresses(
+      token as Dyst,
+      gaugesFactory as GaugeFactory,
+      bribesFactory as BribeFactory,
+      baseFactory as DystFactory,
+      router as DystRouter01,
+      ve as Ve,
+      veDist as VeDist,
+      voter as DystVoter,
+      minter as DystMinter,
+      treasury as GovernanceTreasury
     );
   }
 
@@ -212,18 +209,22 @@ export class Deploy {
     baseFactory: string,
     warmingUpPeriod: number,
   ) {
+    const controller = await Deploy.deployContract(signer, 'Controller') as Controller;
     const token = await Deploy.deployDyst(signer);
+    const ve = await Deploy.deployVe(signer, token.address, controller.address);
     const gaugesFactory = await Deploy.deployGaugeFactory(signer);
     const bribesFactory = await Deploy.deployBribeFactory(signer);
 
-    const ve = await Deploy.deployVe(signer, token.address);
+
     const veDist = await Deploy.deployVeDist(signer, ve.address);
     const voter = await Deploy.deployDystVoter(signer, ve.address, baseFactory, gaugesFactory.address, bribesFactory.address);
-    const minter = await Deploy.deployDystMinter(signer, voter.address, ve.address, veDist.address, warmingUpPeriod);
+
+    const minter = await Deploy.deployDystMinter(signer, ve.address, controller.address, warmingUpPeriod);
 
     await Misc.runAndWait(() => token.setMinter(minter.address));
-    await Misc.runAndWait(() => ve.setVoter(voter.address));
     await Misc.runAndWait(() => veDist.setDepositor(minter.address));
+    await Misc.runAndWait(() => controller.setVeDist(veDist.address));
+    await Misc.runAndWait(() => controller.setVoter(voter.address));
 
     await Misc.runAndWait(() => voter.initialize(voterTokens, minter.address));
     await Misc.runAndWait(() => minter.initialize(

--- a/test/base/ControllerTest.ts
+++ b/test/base/ControllerTest.ts
@@ -1,0 +1,62 @@
+import {Controller} from "../../typechain";
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
+import {ethers} from "hardhat";
+import chai from "chai";
+import {Deploy} from "../../scripts/deploy/Deploy";
+import {TimeUtils} from "../TimeUtils";
+
+const {expect} = chai;
+
+describe("controller tests", function () {
+
+  let snapshotBefore: string;
+  let snapshot: string;
+
+  let owner: SignerWithAddress;
+  let owner2: SignerWithAddress;
+  let controller: Controller;
+
+
+  before(async function () {
+    snapshotBefore = await TimeUtils.snapshot();
+    [owner, owner2] = await ethers.getSigners();
+    controller = await Deploy.deployContract(owner, 'Controller') as Controller;
+    ;
+  });
+
+  after(async function () {
+    await TimeUtils.rollback(snapshotBefore);
+  });
+
+
+  beforeEach(async function () {
+    snapshot = await TimeUtils.snapshot();
+  });
+
+  afterEach(async function () {
+    await TimeUtils.rollback(snapshot);
+  });
+
+  it("set governance and accept test", async function () {
+    await controller.setGovernance(owner2.address);
+    expect(await controller.pendingGovernance()).eq(owner2.address);
+    await expect(controller.acceptGovernance()).revertedWith('Not pending gov');
+    await controller.connect(owner2).acceptGovernance();
+    expect(await controller.governance()).eq(owner2.address);
+  });
+
+  it("setVeDist test", async function () {
+    await controller.setVeDist(owner2.address);
+    expect(await controller.veDist()).eq(owner2.address);
+  });
+
+  it("setVoter test", async function () {
+    await controller.setVoter(owner2.address);
+    expect(await controller.voter()).eq(owner2.address);
+  });
+
+  it("setVoter revert test", async function () {
+    await expect(controller.connect(owner2).setVoter(owner2.address)).revertedWith('Not gov');
+  });
+
+});

--- a/test/base/MinterOld.ts
+++ b/test/base/MinterOld.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:variable-name no-shadowed-variable ban-types no-var-requires no-any */
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { network } from "hardhat";
-import { Dyst, DystMinter, Token, Ve, VeDist } from "../../typechain";
+import {Controller, Dyst, DystMinter, Token, Ve, VeDist } from "../../typechain";
 import {Deploy} from "../../scripts/deploy/Deploy";
 
 const { expect } = require("chai");
@@ -36,11 +36,13 @@ describe("minter old tests", function () {
     [owner] = await ethers.getSigners(0);
     token = await ethers.getContractFactory("Token");
     const Dyst = await ethers.getContractFactory("Dyst");
+    const controllerCtr = await ethers.getContractFactory("Controller");
+    const controller = await controllerCtr.deploy() as Controller;
     const mim = await token.deploy('MIM', 'MIM', 18, owner.address);
     await mim.mint(owner.address, ethers.BigNumber.from("1000000000000000000000000000000"));
     ve_underlying = await Dyst.deploy();
     const vecontract = await ethers.getContractFactory("Ve");
-    ve = await vecontract.deploy(ve_underlying.address);
+    ve = await vecontract.deploy(ve_underlying.address, controller.address);
     await ve_underlying.mint(owner.address, ethers.BigNumber.from("10000000000000000000000000"));
     const treasury = await Deploy.deployGovernanceTreasury(owner);
     const DystFactory = await ethers.getContractFactory("DystFactory");
@@ -56,19 +58,21 @@ describe("minter old tests", function () {
     const bribe_factory = await BribeFactory.deploy();
     await bribe_factory.deployed();
     const DystVoter = await ethers.getContractFactory("DystVoter");
-    const gauge_factory = await DystVoter.deploy(ve.address, factory.address, gauges_factory.address, bribe_factory.address);
-    await gauge_factory.deployed();
+    const voter = await DystVoter.deploy(ve.address, factory.address, gauges_factory.address, bribe_factory.address);
+    await voter.deployed();
 
-    await gauge_factory.initialize([mim.address, ve_underlying.address],owner.address);
+    await voter.initialize([mim.address, ve_underlying.address],owner.address);
     await ve_underlying.approve(ve.address, ethers.BigNumber.from("1000000000000000000"));
     await ve.createLock(ethers.BigNumber.from("1000000000000000000"), 4 * 365 * 86400);
     const VeDist = await ethers.getContractFactory("VeDist");
     ve_dist = await VeDist.deploy(ve.address);
     await ve_dist.deployed();
-    await ve.setVoter(gauge_factory.address);
+
+    await controller.setVeDist(ve_dist.address)
+    await controller.setVoter(voter.address)
 
     const Minter = await ethers.getContractFactory("DystMinter");
-    minter = await Minter.deploy(gauge_factory.address, ve.address, ve_dist.address, 2);
+    minter = await Minter.deploy(ve.address, controller.address, 2);
     await minter.deployed();
     await ve_dist.setDepositor(minter.address);
     await ve_underlying.setMinter(minter.address);
@@ -81,12 +85,12 @@ describe("minter old tests", function () {
 
     const pair = await router.pairFor(mim.address, ve_underlying.address, false);
 
-    await ve_underlying.approve(gauge_factory.address, ethers.BigNumber.from("500000000000000000000000"));
-    await gauge_factory.createGauge(pair);
+    await ve_underlying.approve(voter.address, ethers.BigNumber.from("500000000000000000000000"));
+    await voter.createGauge(pair);
     expect(await ve.balanceOfNFT(1)).to.above(ethers.BigNumber.from("995063075414519385"));
     expect(await ve_underlying.balanceOf(ve.address)).to.be.equal(ethers.BigNumber.from("1000000000000000000"));
 
-    await gauge_factory.vote(1, [pair], [5000]);
+    await voter.vote(1, [pair], [5000]);
   });
 
   it("initialize veNFT", async function () {

--- a/test/base/vote/VeDistTest.ts
+++ b/test/base/vote/VeDistTest.ts
@@ -4,7 +4,7 @@ import chai from "chai";
 import {Deploy} from "../../../scripts/deploy/Deploy";
 import {TimeUtils} from "../../TimeUtils";
 import {BigNumber} from "ethers";
-import {ContractTestHelper, Multicall2, Token, Ve, VeDist} from "../../../typechain";
+import {ContractTestHelper, Controller, Multicall2, Token, Ve, VeDist} from "../../../typechain";
 import {parseUnits} from "ethers/lib/utils";
 import {Misc} from "../../../scripts/Misc";
 
@@ -31,7 +31,8 @@ describe("ve dist tests", function () {
     wmatic = await Deploy.deployContract(owner, 'Token', 'WMATIC', 'WMATIC', 18, owner.address) as Token;
     await wmatic.mint(owner.address, parseUnits('10000'));
 
-    ve = await Deploy.deployVe(owner, wmatic.address);
+    const controller = await Deploy.deployContract(owner, 'Controller') as Controller;
+    ve = await Deploy.deployVe(owner, wmatic.address, controller.address);
     veDist = await Deploy.deployVeDist(owner, ve.address);
 
     await wmatic.approve(ve.address, parseUnits('10000'))
@@ -121,7 +122,8 @@ describe("ve dist tests", function () {
   });
 
   it("claim for early token test", async function () {
-    const ve1 = await Deploy.deployVe(owner, wmatic.address);
+    const controller = await Deploy.deployContract(owner, 'Controller') as Controller;
+    const ve1 = await Deploy.deployVe(owner, wmatic.address, controller.address);
     await wmatic.approve(ve1.address, parseUnits('10000'))
     await ve1.createLock(parseUnits('1'), 60 * 60 * 24 * 14);
     await TimeUtils.advanceBlocksOnTs(WEEK * 2);
@@ -133,7 +135,8 @@ describe("ve dist tests", function () {
   });
 
   it("claim for early token with delay test", async function () {
-    const ve1 = await Deploy.deployVe(owner, wmatic.address);
+    const controller = await Deploy.deployContract(owner, 'Controller') as Controller;
+    const ve1 = await Deploy.deployVe(owner, wmatic.address, controller.address);
     await wmatic.approve(ve1.address, parseUnits('10000'))
     await ve1.createLock(parseUnits('1'), 60 * 60 * 24 * 14);
     await TimeUtils.advanceBlocksOnTs(WEEK * 2);

--- a/test/base/vote/VeTest.ts
+++ b/test/base/vote/VeTest.ts
@@ -140,10 +140,6 @@ describe("ve tests", function () {
     await expect(core.ve.createLockFor(1, 60 * 60 * 24 * 365, Misc.ZERO_ADDRESS)).revertedWith('zero dst')
   });
 
-  it("setVoter revert", async function () {
-    await expect(core.ve.setVoter(Misc.ZERO_ADDRESS)).revertedWith('!voter')
-  });
-
   it("voting revert", async function () {
     await expect(core.ve.voting(1)).revertedWith('!voter')
   });


### PR DESCRIPTION
As part of pre-launch redeployment we have an idea to make VeDist and Voter addresses changeable.
It will be possible to upgrade the most complex contracts without losing any security.
The new contract Controller will be under the control of msig with well-known guys from top Polygon projects so no risks of malicious actions.
Governance still will not have any control over money inside contracts - only possibility migrate to other contracts for future emission.